### PR TITLE
lab/zoo production now depends on number and xp of scientists

### DIFF
--- a/Kerbal Space Program/GameData/StationScience/Parts/StnSciLab/part.cfg
+++ b/Kerbal Space Program/GameData/StationScience/Parts/StnSciLab/part.cfg
@@ -73,6 +73,7 @@ PART
     AutoShutdown = false
     GeneratesHeat = false
     UseSpecialistBonus = false
+    experienceBonus = 0.5
 
     INPUT_RESOURCE
     {

--- a/Kerbal Space Program/GameData/StationScience/Parts/StnSciZoo/part.cfg
+++ b/Kerbal Space Program/GameData/StationScience/Parts/StnSciZoo/part.cfg
@@ -81,6 +81,7 @@ PART
     AutoShutdown = false
     GeneratesHeat = false
     UseSpecialistBonus = false
+    experienceBonus = 0.5
 
     INPUT_RESOURCE
     {

--- a/StationScienceModule.cs
+++ b/StationScienceModule.cs
@@ -31,6 +31,9 @@ namespace StationScience
         [KSPField]
         public string requiredTrait = "NA";
 
+        [KSPField]
+        public double experienceBonus = 0.5;
+
         public bool checkTrait()
         {
             if(requiredTrait == "" || requiredTrait == "NA")
@@ -74,6 +77,17 @@ namespace StationScience
                 }
                 else
                 {
+                    int nsci = 0;
+                    int nstars = 0;
+                    foreach (var crew in part.protoModuleCrew)
+                    {
+                        if (crew.experienceTrait.TypeName == requiredTrait)
+                        {
+                            nsci += 1;
+                            nstars += crew.experienceLevel;
+                        }
+                    }
+                    SetEfficiencyBonus((float)(nsci + nstars * experienceBonus));
                 }
             }
             base.PreProcessing();

--- a/StationScienceModule.cs
+++ b/StationScienceModule.cs
@@ -87,7 +87,7 @@ namespace StationScience
                             nstars += crew.experienceLevel;
                         }
                     }
-                    SetEfficiencyBonus((float)(nsci + nstars * experienceBonus));
+                    SetEfficiencyBonus((float)Math.Max(nsci + nstars * experienceBonus, 1.0));
                 }
             }
             base.PreProcessing();


### PR DESCRIPTION
For now I compute zoo/lab production values as base_rate \* (nsci + experienceBonus \* nstars) where nsci is the number of scientists in a corresponding lab and nstars is the total number of stars among them. For now I set the experienceBonus to 0.5 in order not to make the science production insanely high. You might want to change this value to something else (stock MPL sets it to 5) while simultaneously substantially decreasing the base rate.
